### PR TITLE
Add TLabel (labeling toolkit) and TLabel-Bench (cross-sensor benchmark) to Dataset & Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,8 @@
 - [3D Cal: An Open-Source Software Library for Depth Reconstruction on Vision-Based Tactile Sensors](https://ieeexplore.ieee.org/abstract/document/11433757?casa_token=dh2ci2M60PQAAAAA:dT9OcxehJ6z3W62zGQbFnLnwuaikEojQw2_P1xJVwPaIMpMsrzqp8erVEA8HDUcrJlCzzPDd), Kota et al., RAL 2026
 
 
+
+- [TLabel: Sensor-Agnostic Tactile Data Labeling Toolkit](https://github.com/liesliy/tlabel)
 ## Review
 - [Artificial Sense of Slip—A Review](https://ieeexplore.ieee.org/document/6479676), Francomano et al., IEEE Sensors 2013
 
@@ -1294,6 +1296,7 @@
 - [TVL](https://tactile-vlm.github.io/)
 - [Touch100K](https://cocacola-lab.github.io/Touch100k/)
 
+- [TLabel-Bench: Cross-Sensor Tactile Annotation Benchmark](https://github.com/liesliy/tlabel-bench)
 ### Algorithms
 - [ShapeMap 3-D](https://github.com/rpl-cmu/shape-map-3D)
 - [Tactile SLAM](https://github.com/suddhu/gpis-touch-public)


### PR DESCRIPTION
## Added

### Dataset section
- **TLabel-Bench** — First cross-sensor unified tactile annotation benchmark, providing standardized annotations across GelSight, DIGIT, DMA (and Xense) sensors with evaluation scripts for material classification, episode segmentation, and cross-sensor transfer.

### Library section
- **TLabel** — Sensor-agnostic tactile data labeling toolkit with Panel UI, supporting annotation, quality scoring, batch processing, and multi-format export (HDF5/CSV/JSON). The first open-source tool specifically designed for tactile sensor data labeling.

## Why

Currently there are no cross-sensor annotation benchmarks or dedicated tactile labeling tools listed. TLabel-Bench fills the cross-sensor benchmarking gap, and TLabel provides the labeling toolchain that makes creating such benchmarks possible.

- TLabel: https://github.com/liesliy/tlabel (PyPI: tlabel)
- TLabel-Bench: https://github.com/liesliy/tlabel-bench

Thanks for maintaining this awesome list!