### PR TITLE
Add 2026 textile artificial skin paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,8 @@
 
 - [DexSkin: High-Coverage Conformable Robotic Skin for Learning Contact-Rich Manipulation](https://openreview.net/attachment?id=CNPCSuwxJw&name=pdf), Wistreich et al., CoRL 2025
 
+- [A Self-powered Minimal-Channel Addressable Textile-Based Artificial Skin for Wearable Human–Robot Interfaces](https://doi.org/10.1016/j.nanoen.2026.112233), Zhou et al., Nano Energy 2026 — [source-linked editorial brief](https://roboskin.ai/news/self-powered-textile-artificial-skin-three-channel-robot-control-2026)
+
 
 ## Robotics Applications
 <!---


### PR DESCRIPTION
## Summary

- adds the primary Nano Energy paper to Sensors > Non-Vision-Based
- includes a source-linked editorial brief for readers who want a concise evidence/limitations summary

The paper link is the primary DOI. The editorial brief is secondary.

Disclosure: I maintain RoboSkin.ai, which published the linked editorial brief. This is not a paid or reciprocal-link request.

Related: #38